### PR TITLE
Modern cleanup

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+	"env": {
+		"node": true,
+		"commonjs": true,
+		"es6": true
+	},
+	"parserOptions": {
+		"ecmaVersion": 2018
+	},
+	"extends": "eslint:recommended",
+	"rules": {
+		"require-atomic-updates": "warn",
+		"no-case-declarations": "off",
+		"no-empty": "off",
+		"no-console": "off",
+		"linebreak-style": "off",
+		"no-global-assign": "off",
+		"prefer-const": "error",
+		"no-var": "error",
+		"one-var": [
+			"error",
+			"never"
+		],
+		"indent": [
+			"error",
+			"tab",
+			{
+				"SwitchCase": 1
+			}
+		],
+		"quotes": [
+			"error",
+			"single"
+		],
+		"semi": [
+			"error",
+			"always"
+		]
+	}
+}

--- a/lib/aes-cmac.js
+++ b/lib/aes-cmac.js
@@ -1,85 +1,89 @@
-var crypto = require('crypto');
-var bufferTools = require('./buffer-tools.js');
+const crypto = require('crypto');
+const bufferTools = require('./buffer-tools.js');
 
-var const_Zero = new Buffer('00000000000000000000000000000000', 'hex');
-var const_Rb = new Buffer('00000000000000000000000000000087', 'hex');
-var const_blockSize = 16;
+const zero = Buffer.from('00000000000000000000000000000000', 'hex');
+const rb = Buffer.from('00000000000000000000000000000087', 'hex');
+const blockSize = 16;
 
-exports.generateSubkeys = function (key) {
-  var l = aes(key, const_Zero);
+function generateSubkeys(key) {
+	const cryptedKey = aes(key, zero);
 
-  var subkey1 = bufferTools.bitShiftLeft(l);
-  if (l[0] & 0x80) {
-    subkey1 = bufferTools.xor(subkey1, const_Rb);
-  }
+	let subkey1 = bufferTools.bitShiftLeft(cryptedKey);
+	if (cryptedKey[0] & 0x80) {
+		subkey1 = bufferTools.xor(subkey1, rb);
+	}
 
-  var subkey2 = bufferTools.bitShiftLeft(subkey1);
-  if (subkey1[0] & 0x80) {
-    subkey2 = bufferTools.xor(subkey2, const_Rb);
-  }
+	let subkey2 = bufferTools.bitShiftLeft(subkey1);
+	if (subkey1[0] & 0x80) {
+		subkey2 = bufferTools.xor(subkey2, rb);
+	}
 
-  return { subkey1: subkey1, subkey2: subkey2 };
+	return { subkey1: subkey1, subkey2: subkey2 };
+}
+
+function aes(key, message, algo) {
+	if (!algo) {
+		const keyLengthToCipher = { 16: 'aes-128-cbc', 24: 'aes-192-cbc', 32: 'aes-256-cbc' };
+		algo = keyLengthToCipher[key.length];
+	}
+
+	const cipher = crypto.createCipheriv(algo, key, zero);
+	const result = cipher.update(message);
+	cipher.final();
+	return result;
+}
+
+function aesCmac(key, message, algo) {
+	const { subkey1, subkey2 } = generateSubkeys(key);
+	let blockCount = Math.ceil(message.length / blockSize);
+	let lastBlockCompleteFlag;
+	let lastBlock;
+
+	if (blockCount === 0) {
+		blockCount = 1;
+		lastBlockCompleteFlag = false;
+	} else {
+		lastBlockCompleteFlag = (message.length % blockSize === 0);
+	}
+
+	const lastBlockIndex = blockCount - 1;
+
+	if (lastBlockCompleteFlag) {
+		lastBlock = bufferTools.xor(getMessageBlock(message, lastBlockIndex), subkey1);
+	} else {
+		lastBlock = bufferTools.xor(getMessageBlock(message, lastBlockIndex), subkey2, true);
+	}
+
+	let x = Buffer.from('00000000000000000000000000000000', 'hex');
+	let y;
+
+	for (let index = 0; index < lastBlockIndex; index++) {
+		y = bufferTools.xor(x, getMessageBlock(message, index));
+		x = aes(key, y, algo);
+	}
+
+	y = bufferTools.xor(lastBlock, x);
+
+	return aes(key, y, algo);
+}
+
+function getMessageBlock(message, blockIndex, padded) {
+	const block = Buffer.alloc(blockSize);
+	const start = blockIndex * blockSize;
+	const end = start + blockSize;
+	
+	if (padded) {
+		block.fill(0);
+		message.copy(block, 0, start, end);
+		block[end - start] = 0x80;
+	} else {
+		message.copy(block, 0, start, end);
+	}
+
+	return block;
+}
+
+module.exports = {
+	aesCmac,
+	generateSubkeys
 };
-
-function aes(key, message) {
-  var keyLengthToCipher = { 16: 'aes128', 24: 'aes192', 32: 'aes256' };
-  if (!keyLengthToCipher[key.length]) {
-    throw new Error('Keys must be 128, 192, or 256 bits in length.');
-  }
-  var cipher = crypto.createCipheriv(keyLengthToCipher[key.length], key, const_Zero);
-  var result = cipher.update(message);
-  cipher.final();
-  return result;
-}
-
-exports.aesCmac = function (key, message) {
-  var subkeys = exports.generateSubkeys(key);
-  var blockCount = Math.ceil(message.length / const_blockSize);
-  var lastBlockCompleteFlag, lastBlock, lastBlockIndex;
-
-  if (blockCount === 0) {
-    blockCount = 1;
-    lastBlockCompleteFlag = false
-  } else {
-    lastBlockCompleteFlag = (message.length % const_blockSize === 0);
-  }
-  lastBlockIndex = blockCount -1;
-
-  if (lastBlockCompleteFlag) {
-    lastBlock = bufferTools.xor(getMessageBlock(message, lastBlockIndex), subkeys.subkey1);
-  } else {
-    lastBlock = bufferTools.xor(getPaddedMessageBlock(message, lastBlockIndex), subkeys.subkey2);
-  }
-
-  var x = new Buffer('00000000000000000000000000000000', 'hex');
-  var y;
-
-  for (var index = 0; index < lastBlockIndex; index++) {
-    y = bufferTools.xor(x, getMessageBlock(message, index));
-    x = aes(key, y);
-  }
-  y = bufferTools.xor(lastBlock, x);
-  return aes(key, y);
-};
-
-function getMessageBlock(message, blockIndex) {
-  var block = new Buffer(const_blockSize);
-  var start = blockIndex * const_blockSize;
-  var end = start + const_blockSize;
-
-  message.copy(block, 0, start, end);
-
-  return block;
-}
-
-function getPaddedMessageBlock(message, blockIndex) {
-  var block = new Buffer(const_blockSize);
-  var start = blockIndex * const_blockSize;
-  var end = message.length;
-
-  block.fill(0);
-  message.copy(block, 0, start, end);
-  block[end - start] = 0x80;
-
-  return block;
-}

--- a/lib/buffer-tools.js
+++ b/lib/buffer-tools.js
@@ -1,33 +1,36 @@
-exports.bitShiftLeft = function (buffer) {
-  var shifted = new Buffer(buffer.length);
-  var last = buffer.length - 1;
-  for (var index = 0; index < last; index++) {
-    shifted[index] = buffer[index] << 1;
-    if (buffer[index + 1] & 0x80) {
-      shifted[index] += 0x01;
-    }
-  }
-  shifted[last] = buffer[last] << 1;
-  return shifted;
+function bitShiftLeft(buffer) {
+	const shifted = Buffer.alloc(buffer.length);
+	const last = buffer.length - 1;
+
+	for (let index = 0; index < last; index++) {
+		let value = buffer[index] << 1;
+
+		if (buffer[index + 1] & 0x80) {
+			value += 0x01;
+		}
+
+		shifted[index] = value;
+	}
+
+	shifted[last] = buffer[last] << 1;
+
+	return shifted;
 }
 
-exports.xor = function (bufferA, bufferB) {
-  var length = Math.min(bufferA.length, bufferB.length);
-  var output = new Buffer(length);
-  for (var index = 0; index < length; index++) {
-    output[index] = bufferA[index] ^ bufferB[index];
-  }
-  return output;
+function xor(bufferA, bufferB) {
+	const length = Math.min(bufferA.length, bufferB.length);
+	const output = Buffer.alloc(length);
+
+	for (let index = 0; index < length; index++) {
+		const value = bufferA[index] ^ bufferB[index];
+		output[index] = value;
+	}
+
+	return output;
 }
 
-var bitmasks = [0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01];
 
-exports.toBinaryString = function (buffer) {
-  var binary = '';
-  for (var bufferIndex = 0; bufferIndex < buffer.length; bufferIndex++) {
-    for (var bitmaskIndex = 0; bitmaskIndex < bitmasks.length; bitmaskIndex++) {
-      binary += (buffer[bufferIndex] & bitmasks[bitmaskIndex]) ? '1' : '0';
-    }
-  }
-  return binary;
-}
+module.exports = {
+	bitShiftLeft,
+	xor
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-aes-cmac",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "A pure Node.js implementation of the AES-CMAC algorithm (NIST 800-38B / RFC 4493).",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Removed the deprecated Buffer constructor calls and replaced with `Buffer.from()` and `Buffer.alloc()`

Removed unused `toBinaryString` from buffer-tools

Changed from cipher algorithm alias to real names (`aes128`, `aes192`, and `aes256` to `aes-128-cbc`, `aes-192-cbc`, and `aes-256-cbc`) to improve compatibility with Electron, see electron/electron#16195 for more details

Now allows users to provide their own cipher algorithm name. To keep backwards compatibility, if an algorithm is not given then defaults to the old lookup table method

Condensed getMessageBlock and getPaddedMessageBlock into one function to remove duplicate code

And finally just some general changes to make things a bit more modern/readable